### PR TITLE
Zipfile flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **region**: AWS Region the Elastic Beanstalk app is running in. Defaults to 'us-east-1'. Please be aware that this must match the region of the elastic beanstalk app.
  * **app**: Elastic Beanstalk application name.
  * **env**: Elastic Beanstalk environment name which will be updated.
+ * **zipfile**: The zipfile that you want to deploy. _**Note:**_ you also need to use the `skip-cleanup` or the zipfile you are trying to upload will be removed during cleanup.
  * **bucket_name**: Bucket name to upload app to.
 
 #### Examples:

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -112,12 +112,6 @@ module DPL
         alternatives.any? ? option(*alternatives) : raise(Error, "missing #{name}")
       end
     end
-    
-    def optional_option(name, *alternatives)
-      options.fetch(name) do
-        alternatives.any? ? option(*alternatives) : nil
-      end
-    end
 
     def deploy
       setup_git_credentials

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -23,7 +23,7 @@ module DPL
         create_bucket unless bucket_exists?
         #zip_file = option(:zipfile) || create_zip
 
-        if optional_option(:zipfile)
+        if options[:zipfile]
           zip_file = File.join(Dir.pwd, option(:zipfile))
         else
           zip_file = create_zip
@@ -53,8 +53,7 @@ module DPL
       end
 
       def region
-        puts DEFAULT_REGION
-        optional_option(:region) || DEFAULT_REGION
+        option(:region) || DEFAULT_REGION
       end
 
       def bucket_name

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -21,14 +21,14 @@ module DPL
 
       def push_app
         create_bucket unless bucket_exists?
-        #zip_file = option(:zipfile) || create_zip
 
-        if options[:zipfile]
-          zip_file = File.join(Dir.pwd, option(:zipfile))
+        zipname, zipfile = if options[:zipfile]
+          options[:zipfile], File.join(Dir.pwd, options[:zipfile])
         else
-          zip_file = create_zip
+          archive_name, create_zip
         end
-        s3_object = upload(archive_name, zip_file)
+
+        s3_object = upload(zipname, zip_file)
         sleep 5 #s3 eventual consistency
         version = create_app_version(s3_object)
         update_app(version)
@@ -49,7 +49,7 @@ module DPL
       end
 
       def archive_name
-        "#{version_label}.zip"
+        @archive_name ||= "#{version_label}.zip"
       end
 
       def region


### PR DESCRIPTION
I dug through `provider.rb` and saw that ends up doing a `git stash` unless you pass the `--skip-cleanup` flag to the cli. That is the reason that you weren't able to upload the file, it was being removed while the script was running and then added right back in when the command finished.

I updated the `README.md` with the caveat of the `zipfile` flag and made sure that the name of the zip on s3 is the same name of the zip on your local machine.
